### PR TITLE
Vulkan improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 3.15)
+﻿cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 project("Miracle")
 

--- a/Demos/Demo1/Demo.cpp
+++ b/Demos/Demo1/Demo.cpp
@@ -188,6 +188,21 @@ int main() {
 				if (Keyboard::isKeyPressed(KeyboardKey::keyEscape)) {
 					CurrentApp::close();
 				}
+
+				if (Keyboard::isKeyPressed(KeyboardKey::keyF1)) {
+					Renderer::setVsync(!Renderer::isUsingVsync());
+				}
+
+				if (Keyboard::isKeyPressed(KeyboardKey::keyF2)) {
+					Renderer::setTripleBuffering(!Renderer::isUsingTripleBuffering());
+				}
+
+				if (Keyboard::isKeyPressed(KeyboardKey::keyF3)) {
+					Renderer::setVsyncAndTripleBuffering(
+						!Renderer::isUsingVsync(),
+						!Renderer::isUsingTripleBuffering()
+					);
+				}
 			}
 		}
 	);

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2023 Henrik Soltvedt Nyhammer
+Copyright (c) 2021-2024 Henrik Soltvedt Nyhammer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Miracle/include/Miracle/App.hpp
+++ b/Miracle/include/Miracle/App.hpp
@@ -33,6 +33,7 @@ namespace Miracle {
 		friend class Logger;
 		friend class Window;
 		friend class Keyboard;
+		friend class Renderer;
 		friend class CurrentScene;
 		friend class TextInput;
 		friend class Clipboard;

--- a/Miracle/include/Miracle/Application/Graphics/IGraphicsContext.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/IGraphicsContext.hpp
@@ -11,6 +11,7 @@ namespace Miracle::Application {
 	public:
 		virtual ~IGraphicsContext() = default;
 
+		// Graphics command
 		virtual void setViewport(
 			float x,
 			float y,
@@ -18,6 +19,7 @@ namespace Miracle::Application {
 			float height
 		) = 0;
 
+		// Graphics command
 		virtual void setScissor(
 			int x,
 			int y,
@@ -25,15 +27,21 @@ namespace Miracle::Application {
 			unsigned int height
 		) = 0;
 
+		// Graphics command
 		virtual void draw(uint32_t vertexCount) = 0;
 
+		// Graphics command
 		virtual void drawIndexed(uint32_t indexCount) = 0;
 
 		virtual IContextTarget& getTarget() = 0;
 
-		virtual void recordCommands(const std::function<void()>& recording) = 0;
+		virtual void recordGraphicsCommands(const std::function<void()>& recording) = 0;
 
-		virtual void submitRecording() = 0;
+		virtual void recordTransferCommands(const std::function<void()>& recording) = 0;
+
+		virtual void submitGraphicsRecording() = 0;
+
+		virtual void submitTransferRecording() = 0;
 
 		virtual void waitForDeviceIdle() = 0;
 	};

--- a/Miracle/include/Miracle/Application/Graphics/IGraphicsPipeline.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/IGraphicsPipeline.hpp
@@ -8,8 +8,10 @@ namespace Miracle::Application {
 	public:
 		virtual ~IGraphicsPipeline() = default;
 
+		// Graphics command
 		virtual void bind() = 0;
 
+		// Graphics command
 		virtual void pushConstants(const PushConstants& constants) = 0;
 	};
 

--- a/Miracle/include/Miracle/Application/Graphics/IIndexBuffer.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/IIndexBuffer.hpp
@@ -11,6 +11,7 @@ namespace Miracle::Application {
 
 		virtual uint32_t getIndexCount() const = 0;
 
+		// Graphics command
 		virtual void bind() = 0;
 	};
 

--- a/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
@@ -27,6 +27,7 @@ namespace Miracle::Application {
 	struct SwapchainInitProps {
 		bool useSrgb;
 		bool useVsync;
+		bool useTripleBuffering;
 	};
 
 	namespace SwapchainErrors {

--- a/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
@@ -24,6 +24,14 @@ namespace Miracle::Application {
 		virtual void swap() = 0;
 
 		virtual void recreate() = 0;
+
+		virtual bool isUsingVsync() const = 0;
+
+		virtual void setVsync(bool useVsync) = 0;
+
+		virtual bool isUsingTripleBuffering() const = 0;
+
+		virtual void setTripleBuffering(bool useTripleBuffering) = 0;
 	};
 
 	struct SwapchainInitProps {

--- a/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
@@ -15,8 +15,10 @@ namespace Miracle::Application {
 
 		virtual SwapchainImageSize getImageSize() const = 0;
 
+		// Graphics command
 		virtual void beginRenderPass(ColorRgb clearColor) = 0;
 
+		// Graphics command
 		virtual void endRenderPass() = 0;
 
 		virtual void swap() = 0;

--- a/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/ISwapchain.hpp
@@ -25,7 +25,6 @@ namespace Miracle::Application {
 	};
 
 	struct SwapchainInitProps {
-		bool useSrgb;
 		bool useVsync;
 		bool useTripleBuffering;
 	};

--- a/Miracle/include/Miracle/Application/Graphics/IVertexBuffer.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/IVertexBuffer.hpp
@@ -11,6 +11,7 @@ namespace Miracle::Application {
 
 		virtual uint32_t getVertexCount() const = 0;
 
+		// Graphics command
 		virtual void bind() = 0;
 	};
 

--- a/Miracle/include/Miracle/Application/Graphics/Renderer.hpp
+++ b/Miracle/include/Miracle/Application/Graphics/Renderer.hpp
@@ -43,6 +43,29 @@ namespace Miracle::Application {
 
 		~Renderer();
 
+		bool isUsingVsync() const { return m_swapchain->isUsingVsync(); }
+
+		void setVsync(bool useVsync) {
+			m_swapchain->setVsync(useVsync);
+			m_context.waitForDeviceIdle();
+			m_swapchain->recreate();
+		}
+
+		bool isUsingTripleBuffering() const { return m_swapchain->isUsingTripleBuffering(); }
+
+		void setTripleBuffering(bool useTripleBuffering) {
+			m_swapchain->setTripleBuffering(useTripleBuffering);
+			m_context.waitForDeviceIdle();
+			m_swapchain->recreate();
+		}
+
+		void setVsyncAndTripleBuffering(bool useVsync, bool useTripleBuffering) {
+			m_swapchain->setVsync(useVsync);
+			m_swapchain->setTripleBuffering(useTripleBuffering);
+			m_context.waitForDeviceIdle();
+			m_swapchain->recreate();
+		}
+
 		bool render(const Scene& scene);
 
 	private:

--- a/Miracle/include/Miracle/Application/Mappings.hpp
+++ b/Miracle/include/Miracle/Application/Mappings.hpp
@@ -31,7 +31,6 @@ namespace Miracle::Application {
 		) {
 			return RendererInitProps{
 				.swapchainInitProps = SwapchainInitProps{
-					.useSrgb            = false,
 					.useVsync           = false,
 					.useTripleBuffering = false
 				},

--- a/Miracle/include/Miracle/Application/Mappings.hpp
+++ b/Miracle/include/Miracle/Application/Mappings.hpp
@@ -31,8 +31,9 @@ namespace Miracle::Application {
 		) {
 			return RendererInitProps{
 				.swapchainInitProps = SwapchainInitProps{
-					.useSrgb  = false,
-					.useVsync = false
+					.useSrgb            = false,
+					.useVsync           = false,
+					.useTripleBuffering = false
 				},
 				.meshes               = rendererConfig.meshes
 			};

--- a/Miracle/include/Miracle/Application/Mappings.hpp
+++ b/Miracle/include/Miracle/Application/Mappings.hpp
@@ -31,8 +31,8 @@ namespace Miracle::Application {
 		) {
 			return RendererInitProps{
 				.swapchainInitProps = SwapchainInitProps{
-					.useVsync           = false,
-					.useTripleBuffering = false
+					.useVsync           = rendererConfig.swapchainConfig.useVsync,
+					.useTripleBuffering = rendererConfig.swapchainConfig.useTripleBuffering
 				},
 				.meshes               = rendererConfig.meshes
 			};

--- a/Miracle/include/Miracle/Common/Math/ColorRgb.hpp
+++ b/Miracle/include/Miracle/Common/Math/ColorRgb.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <cmath>
 
 namespace Miracle {
+	// Linear RGB color
 	struct ColorRgb {
 		float redChannel = {};
 		float greenChannel = {};
@@ -14,20 +16,28 @@ namespace Miracle {
 
 		/* ----- CONVERTERS ----- */
 
-		// Returns color-code in format #RRGGBB
-		constexpr uint32_t toColorCode() const {
-			return (static_cast<uint32_t>(redChannel   * 255.0f) << 16u)
-				 + (static_cast<uint32_t>(greenChannel * 255.0f) <<  8u)
-				 +  static_cast<uint32_t>(blueChannel  * 255.0f);
+		// Creates ColorRgb converted from non-linear sRGB color channels
+		static ColorRgb createFromNonlinearSrgb(float redChannel, float greenChannel, float blueChannel) {
+			return ColorRgb{
+				.redChannel   = redChannel   > 0.04045f
+					? std::pow((redChannel   + 0.055f) / 1.055f, 2.4f)
+					: redChannel   / 12.92f,
+				.greenChannel = greenChannel > 0.04045f
+					? std::pow((greenChannel + 0.055f) / 1.055f, 2.4f)
+					: greenChannel / 12.92f,
+				.blueChannel  = blueChannel  > 0.04045f
+					? std::pow((blueChannel  + 0.055f) / 1.055f, 2.4f)
+					: blueChannel  / 12.92f
+			};
 		}
 
-		// Creates ColorRgb from color-code in format #RRGGBB
-		static constexpr ColorRgb createFromColorCode(uint32_t colorCode) {
-			return ColorRgb{
-				.redChannel   = static_cast<float>((colorCode >> 16u) & 0xffu) / 255.0f,
-				.greenChannel = static_cast<float>((colorCode >>  8u) & 0xffu) / 255.0f,
-				.blueChannel  = static_cast<float>( colorCode         & 0xffu) / 255.0f,
-			};
+		// Creates ColorRgb from non-linear sRGB color-code in format #RRGGBB
+		static ColorRgb createFromNonlinearSrgbColorCode(uint32_t colorCode) {
+			return createFromNonlinearSrgb(
+				static_cast<float>((colorCode >> 16u) & 0xffu) / 255.0f,
+				static_cast<float>((colorCode >>  8u) & 0xffu) / 255.0f,
+				static_cast<float>( colorCode         & 0xffu) / 255.0f
+			);
 		}
 	};
 
@@ -35,13 +45,13 @@ namespace Miracle {
 	public:
 		ColorRgbs() = delete;
 
-		static constexpr ColorRgb red     = ColorRgb::createFromColorCode(0xFF0000);
-		static constexpr ColorRgb green   = ColorRgb::createFromColorCode(0x00FF00);
-		static constexpr ColorRgb blue    = ColorRgb::createFromColorCode(0x0000FF);
-		static constexpr ColorRgb cyan    = ColorRgb::createFromColorCode(0x00FFFF);
-		static constexpr ColorRgb magenta = ColorRgb::createFromColorCode(0xFF00FF);
-		static constexpr ColorRgb yellow  = ColorRgb::createFromColorCode(0xFFFF00);
-		static constexpr ColorRgb black   = ColorRgb::createFromColorCode(0x000000);
-		static constexpr ColorRgb white   = ColorRgb::createFromColorCode(0xFFFFFF);
+		static inline const ColorRgb red     = ColorRgb::createFromNonlinearSrgbColorCode(0xFF0000);
+		static inline const ColorRgb green   = ColorRgb::createFromNonlinearSrgbColorCode(0x00FF00);
+		static inline const ColorRgb blue    = ColorRgb::createFromNonlinearSrgbColorCode(0x0000FF);
+		static inline const ColorRgb cyan    = ColorRgb::createFromNonlinearSrgbColorCode(0x00FFFF);
+		static inline const ColorRgb magenta = ColorRgb::createFromNonlinearSrgbColorCode(0xFF00FF);
+		static inline const ColorRgb yellow  = ColorRgb::createFromNonlinearSrgbColorCode(0xFFFF00);
+		static inline const ColorRgb black   = ColorRgb::createFromNonlinearSrgbColorCode(0x000000);
+		static inline const ColorRgb white   = ColorRgb::createFromNonlinearSrgbColorCode(0xFFFFFF);
 	};
 }

--- a/Miracle/include/Miracle/Common/Models/AppearanceConfig.hpp
+++ b/Miracle/include/Miracle/Common/Models/AppearanceConfig.hpp
@@ -8,10 +8,6 @@ namespace Miracle {
 	struct AppearanceConfig {
 		bool visible = true;
 		size_t meshIndex = 0;
-		ColorRgb color = ColorRgb{
-			.redChannel   = 0.75f,
-			.greenChannel = 0.75f,
-			.blueChannel  = 0.75f
-		};
+		ColorRgb color = ColorRgb::createFromNonlinearSrgbColorCode(0xBFBFBF);
 	};
 }

--- a/Miracle/include/Miracle/Common/Models/RendererConfig.hpp
+++ b/Miracle/include/Miracle/Common/Models/RendererConfig.hpp
@@ -2,10 +2,12 @@
 
 #include <vector>
 
-#include <Miracle/Common/Models/Mesh.hpp>
+#include "SwapchainConfig.hpp"
+#include "Mesh.hpp"
 
 namespace Miracle {
 	struct RendererConfig {
+		SwapchainConfig swapchainConfig = {};
 		std::vector<Mesh> meshes = {};
 	};
 }

--- a/Miracle/include/Miracle/Common/Models/SceneConfig.hpp
+++ b/Miracle/include/Miracle/Common/Models/SceneConfig.hpp
@@ -9,11 +9,7 @@
 
 namespace Miracle {
 	struct SceneConfig {
-		ColorRgb backgroundColor = {
-			.redChannel   = 0.125f,
-			.greenChannel = 0.125f,
-			.blueChannel  = 0.125f
-		};
+		ColorRgb backgroundColor = ColorRgb::createFromNonlinearSrgbColorCode(0x202020);
 		std::vector<EntityConfig> entityConfigs = {};
 		std::function<void(EntityId)> entityCreatedCallback = [](EntityId) {};
 		std::function<void(EntityId)> entityDestroyedCallback = [](EntityId) {};

--- a/Miracle/include/Miracle/Common/Models/SwapchainConfig.hpp
+++ b/Miracle/include/Miracle/Common/Models/SwapchainConfig.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace Miracle {
+	struct SwapchainConfig {
+		bool useVsync           = false;
+		bool useTripleBuffering = false;
+	};
+}

--- a/Miracle/include/Miracle/Interface/Renderer.hpp
+++ b/Miracle/include/Miracle/Interface/Renderer.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <Miracle/App.hpp>
+
+namespace Miracle {
+	class Renderer {
+	public:
+		Renderer() = delete;
+
+		static bool isUsingVsync() {
+			if (App::s_currentApp == nullptr) [[unlikely]] throw NoAppRunningError();
+
+			return App::s_currentApp->m_dependencies->getRenderer().isUsingVsync();
+		}
+
+		static void setVsync(bool useVsync) {
+			if (App::s_currentApp == nullptr) [[unlikely]] throw NoAppRunningError();
+
+			App::s_currentApp->m_dependencies->getRenderer().setVsync(useVsync);
+		}
+
+		static bool isUsingTripleBuffering() {
+			if (App::s_currentApp == nullptr) [[unlikely]] throw NoAppRunningError();
+
+			return App::s_currentApp->m_dependencies->getRenderer().isUsingTripleBuffering();
+		}
+
+		static void setTripleBuffering(bool useTripleBuffering) {
+			if (App::s_currentApp == nullptr) [[unlikely]] throw NoAppRunningError();
+
+			App::s_currentApp->m_dependencies->getRenderer().setTripleBuffering(useTripleBuffering);
+		}
+
+		static void setVsyncAndTripleBuffering(bool useVsync, bool useTripleBuffering) {
+			if (App::s_currentApp == nullptr) [[unlikely]] throw NoAppRunningError();
+
+			App::s_currentApp->m_dependencies->getRenderer()
+				.setVsyncAndTripleBuffering(useVsync, useTripleBuffering);
+		}
+	};
+}

--- a/Miracle/include/Miracle/Miracle.hpp
+++ b/Miracle/include/Miracle/Miracle.hpp
@@ -8,6 +8,7 @@
 #include "Interface/Logger.hpp"
 #include "Interface/Window.hpp"
 #include "Interface/Keyboard.hpp"
+#include "Interface/Renderer.hpp"
 #include "Interface/CurrentScene.hpp"
 #include "Interface/TextInput.hpp"
 #include "Interface/Clipboard.hpp"

--- a/Miracle/src/Miracle/Application/Graphics/Renderer.cpp
+++ b/Miracle/src/Miracle/Application/Graphics/Renderer.cpp
@@ -79,7 +79,7 @@ namespace Miracle::Application {
 
 		auto viewProjection = view * projection;
 
-		m_context.recordCommands(
+		m_context.recordGraphicsCommands(
 			[&]() {
 				m_swapchain->beginRenderPass(scene.getBackgroundColor());
 				m_context.setViewport(0.0f, 0.0f, swapchainImageSize.width, swapchainImageSize.height);
@@ -117,7 +117,7 @@ namespace Miracle::Application {
 			}
 		);
 
-		m_context.submitRecording();
+		m_context.submitGraphicsRecording();
 
 		m_swapchain->swap();
 

--- a/Miracle/src/Miracle/Application/Graphics/Renderer.cpp
+++ b/Miracle/src/Miracle/Application/Graphics/Renderer.cpp
@@ -18,8 +18,6 @@ namespace Miracle::Application {
 		m_pipeline(m_api.createGraphicsPipeline(m_fileAccess, m_context, *m_swapchain.get())),
 		m_meshBuffersList(createMeshBuffersList(initProps.meshes))
 	{
-		auto swapchainImageSize = m_swapchain->getImageSize();
-
 		m_logger.info("Renderer created");
 	}
 

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/BufferUtilities.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/BufferUtilities.cpp
@@ -61,37 +61,21 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		vk::Buffer source,
 		vk::DeviceSize size
 	) {
-		m_context.getCommandBuffer().reset();
-		m_context.getCommandBuffer().begin(
-			vk::CommandBufferBeginInfo{
-				.flags            = {},
-				.pInheritanceInfo = {}
+		m_context.recordTransferCommands(
+			[&]() {
+				m_context.getTransferCommandBuffer().copyBuffer(
+					source,
+					destination,
+					vk::BufferCopy{
+						.srcOffset = 0,
+						.dstOffset = 0,
+						.size = size
+					}
+				);
 			}
 		);
 
-		m_context.getCommandBuffer().copyBuffer(
-			source,
-			destination,
-			vk::BufferCopy{
-				.srcOffset = 0,
-				.dstOffset = 0,
-				.size      = size
-			}
-		);
-
-		m_context.getCommandBuffer().end();
-		m_context.getGraphicsQueue().submit(
-			vk::SubmitInfo{
-				.waitSemaphoreCount   = 0,
-				.pWaitSemaphores      = nullptr,
-				.pWaitDstStageMask    = nullptr,
-				.commandBufferCount   = 1,
-				.pCommandBuffers      = &*m_context.getCommandBuffer(),
-				.signalSemaphoreCount = 0,
-				.pSignalSemaphores    = nullptr
-			}
-		);
-
-		m_context.getGraphicsQueue().waitIdle();
+		m_context.submitTransferRecording();
+		m_context.waitForDeviceIdle();
 	}
 }

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
@@ -33,6 +33,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	bool DeviceExplorer::isDeviceSupported(const DeviceInfo& deviceInfo) {
 		return deviceInfo.queueFamilyIndices.graphicsFamilyIndex.has_value()
 			&& deviceInfo.queueFamilyIndices.presentFamilyIndex.has_value()
+			&& deviceInfo.queueFamilyIndices.transferFamilyIndex.has_value()
 			&& deviceInfo.extensionSupport.swapchainSupport.has_value()
 			&& deviceInfo.extensionSupport.swapchainSupport.value().hasDoubleBufferingSupport
 			&& !deviceInfo.extensionSupport.swapchainSupport.value().surfaceFormats.empty()
@@ -62,7 +63,20 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 				queueFamilyIndices.presentFamilyIndex = static_cast<uint32_t>(i);
 			}
 
+			if (
+				!queueFamilyIndices.transferFamilyIndex.has_value()
+					&& queueFamilyPropertiesList[i].queueFlags & vk::QueueFlagBits::eTransfer
+					&& !(queueFamilyPropertiesList[i].queueFlags & vk::QueueFlagBits::eGraphics)
+					&& !(queueFamilyPropertiesList[i].queueFlags & vk::QueueFlagBits::eCompute)
+			) {
+				queueFamilyIndices.transferFamilyIndex = static_cast<uint32_t>(i);
+			}
+
 			if (queueFamilyIndices.hasAllIndicesSet()) break;
+		}
+
+		if (!queueFamilyIndices.transferFamilyIndex.has_value()) {
+			queueFamilyIndices.transferFamilyIndex = queueFamilyIndices.graphicsFamilyIndex;
 		}
 
 		return queueFamilyIndices;

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
@@ -44,10 +44,10 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	) {
 		auto queueFamilyIndices = QueueFamilyIndices{};
 
-		auto queueFamiliesProperties = device.getQueueFamilyProperties();
+		auto queueFamilyPropertiesList = device.getQueueFamilyProperties();
 
-		for (size_t i = 0; i < queueFamiliesProperties.size(); i++) {
-			if (queueFamiliesProperties[i].queueFlags & vk::QueueFlagBits::eGraphics) {
+		for (size_t i = 0; i < queueFamilyPropertiesList.size(); i++) {
+			if (queueFamilyPropertiesList[i].queueFlags & vk::QueueFlagBits::eGraphics) {
 				queueFamilyIndices.graphicsFamilyIndex = static_cast<uint32_t>(i);
 			}
 

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
@@ -47,11 +47,17 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		auto queueFamilyPropertiesList = device.getQueueFamilyProperties();
 
 		for (size_t i = 0; i < queueFamilyPropertiesList.size(); i++) {
-			if (queueFamilyPropertiesList[i].queueFlags & vk::QueueFlagBits::eGraphics) {
+			if (
+				!queueFamilyIndices.graphicsFamilyIndex.has_value()
+					&& queueFamilyPropertiesList[i].queueFlags & vk::QueueFlagBits::eGraphics
+			) {
 				queueFamilyIndices.graphicsFamilyIndex = static_cast<uint32_t>(i);
 			}
 
-			if (device.getSurfaceSupportKHR(i, *surface)) {
+			if (
+				!queueFamilyIndices.presentFamilyIndex.has_value()
+					&& device.getSurfaceSupportKHR(i, *surface)
+			) {
 				queueFamilyIndices.presentFamilyIndex = static_cast<uint32_t>(i);
 			}
 
@@ -70,6 +76,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		for (auto& extensionProperties : device.enumerateDeviceExtensionProperties()) {
 			if (std::strcmp(extensionProperties.extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
 				extensionSupport.swapchainSupport = querySwapchainSupport(device, surface);
+				break;
 			}
 		}
 

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceExplorer.cpp
@@ -34,6 +34,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		return deviceInfo.queueFamilyIndices.graphicsFamilyIndex.has_value()
 			&& deviceInfo.queueFamilyIndices.presentFamilyIndex.has_value()
 			&& deviceInfo.extensionSupport.swapchainSupport.has_value()
+			&& deviceInfo.extensionSupport.swapchainSupport.value().hasDoubleBufferingSupport
 			&& !deviceInfo.extensionSupport.swapchainSupport.value().surfaceFormats.empty()
 			&& deviceInfo.extensionSupport.swapchainSupport.value().hasImmediateModePresentationSupport;
 	}
@@ -103,10 +104,10 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		}
 
 		return SwapchainSupport{
-			.minImageCount                       = surfaceCapabilities.minImageCount,
-			.maxImageCount                       = surfaceCapabilities.maxImageCount != 0
-				? std::optional(surfaceCapabilities.maxImageCount)
-				: std::nullopt,
+			.hasDoubleBufferingSupport           = surfaceCapabilities.minImageCount <= 2
+				&& (surfaceCapabilities.maxImageCount == 0 || surfaceCapabilities.maxImageCount >= 2),
+			.hasTripleBufferingSupport           = surfaceCapabilities.minImageCount <= 3
+				&& (surfaceCapabilities.maxImageCount == 0 || surfaceCapabilities.maxImageCount >= 3),
 			.surfaceFormats                      = device.getSurfaceFormatsKHR(*surface),
 			.hasImmediateModePresentationSupport = hasImmediateMode,
 			.hasMailboxModePresentationSupport   = hasMailboxMode

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceInfo.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceInfo.hpp
@@ -33,8 +33,8 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	};
 
 	struct SwapchainSupport {
-		uint32_t minImageCount = {};
-		std::optional<uint32_t> maxImageCount = {};
+		bool hasDoubleBufferingSupport = {};
+		bool hasTripleBufferingSupport = {};
 		std::vector<vk::SurfaceFormatKHR> surfaceFormats = {};
 		bool hasImmediateModePresentationSupport = {};
 		bool hasMailboxModePresentationSupport = {};

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceInfo.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/DeviceInfo.hpp
@@ -11,10 +11,12 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	struct QueueFamilyIndices {
 		std::optional<uint32_t> graphicsFamilyIndex = {};
 		std::optional<uint32_t> presentFamilyIndex = {};
+		std::optional<uint32_t> transferFamilyIndex = {};
 
 		bool hasAllIndicesSet() const {
 			return graphicsFamilyIndex.has_value()
-				&& presentFamilyIndex.has_value();
+				&& presentFamilyIndex.has_value()
+				&& transferFamilyIndex.has_value();
 		}
 
 		std::set<uint32_t> createSetOfAllUniqueIndices() const {
@@ -26,6 +28,10 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 
 			if (presentFamilyIndex.has_value()) {
 				uniqueIndices.insert(presentFamilyIndex.value());
+			}
+
+			if (transferFamilyIndex.has_value()) {
+				uniqueIndices.insert(transferFamilyIndex.value());
 			}
 
 			return uniqueIndices;

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.cpp
@@ -161,13 +161,16 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	SurfaceExtent GraphicsContext::getCurrentSurfaceExtent() const {
 		auto surfaceCapabilities = m_physicalDevice.getSurfaceCapabilitiesKHR(*m_surface);
 
-		return SurfaceExtent{
-			.extent    = surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()
-				? std::optional(surfaceCapabilities.currentExtent)
-				: std::nullopt,
-			.minExtent = surfaceCapabilities.minImageExtent,
-			.maxExtent = surfaceCapabilities.maxImageExtent
-		};
+		return surfaceCapabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()
+			? SurfaceExtent{
+				.extent = surfaceCapabilities.currentExtent
+			}
+			: SurfaceExtent{
+				.extent = SurfaceExtentBounds{
+					.minExtent = surfaceCapabilities.minImageExtent,
+					.maxExtent = surfaceCapabilities.maxImageExtent
+				}
+			};
 	}
 
 	void GraphicsContext::recreateSemaphores() {

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.hpp
@@ -19,8 +19,8 @@
 namespace Miracle::Infrastructure::Graphics::Vulkan {
 	class GraphicsContext : public Application::IGraphicsContext {
 	private:
-		static constexpr inline uint32_t s_vulkanApiVersion = VK_API_VERSION_1_1;
-		static constexpr inline auto s_validationLayerNames = std::array{ "VK_LAYER_KHRONOS_validation" };
+		static constexpr uint32_t s_vulkanApiVersion = VK_API_VERSION_1_1;
+		static constexpr auto s_validationLayerNames = std::array{ "VK_LAYER_KHRONOS_validation" };
 
 		Application::ILogger& m_logger;
 		IContextTarget& m_target;

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.hpp
@@ -36,13 +36,16 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		vk::raii::Device m_device = nullptr;
 		vk::raii::Queue m_graphicsQueue = nullptr;
 		vk::raii::Queue m_presentQueue = nullptr;
-		vk::raii::CommandPool m_commandPool = nullptr;
-		std::vector<vk::raii::CommandBuffer> m_commandBuffers;
-		std::vector<vk::raii::Semaphore> m_commandExecutionWaitSemaphores;
-		std::vector<vk::raii::Semaphore> m_commandExecutionSignalSemaphores;
-		std::vector<vk::raii::Fence> m_commandExecutionSignalFences;
-		size_t m_currentCommandBufferIndex = 0;
-		vma::Allocator m_allocator = nullptr;
+		vk::raii::Queue m_transferQueue = nullptr;
+		vk::raii::CommandPool m_graphicsCommandPool = nullptr;
+		vk::raii::CommandPool m_transferCommandPool = nullptr;
+		std::vector<vk::raii::CommandBuffer> m_graphicsCommandBuffers;
+		vk::raii::CommandBuffer m_transferCommandBuffer = nullptr;
+		std::vector<vk::raii::Fence> m_graphicsCommandExecutionCompletedFences;
+		std::vector<vk::raii::Semaphore> m_graphicsCommandExecutionCompletedSemaphores;
+		std::vector<vk::raii::Semaphore> m_graphicsCommandPresentCompletedSemaphores;
+		size_t m_currentGraphicsCommandBufferIndex = 0;
+		vma::Allocator m_allocator;
 
 	public:
 		GraphicsContext(
@@ -73,9 +76,13 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 
 		IContextTarget& getTarget() override { return m_target; }
 
-		virtual void recordCommands(const std::function<void()>& recording) override;
+		virtual void recordGraphicsCommands(const std::function<void()>& recording) override;
 
-		virtual void submitRecording() override;
+		virtual void recordTransferCommands(const std::function<void()>& recording) override;
+
+		virtual void submitGraphicsRecording() override;
+
+		virtual void submitTransferRecording() override;
 
 		virtual void waitForDeviceIdle() override;
 
@@ -89,16 +96,22 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 
 		const vk::raii::Queue& getPresentQueue() const { return m_presentQueue; }
 
-		const vk::raii::CommandBuffer& getCommandBuffer() const {
-			return m_commandBuffers[m_currentCommandBufferIndex];
+		const vk::raii::Queue& getTransferQueue() const { return m_transferQueue; }
+
+		const vk::raii::CommandBuffer& getGraphicsCommandBuffer() const {
+			return m_graphicsCommandBuffers[m_currentGraphicsCommandBufferIndex];
 		}
 
-		const vk::raii::Semaphore& getCommandExecutionWaitSemaphore() const {
-			return m_commandExecutionWaitSemaphores[m_currentCommandBufferIndex];
+		const vk::raii::CommandBuffer& getTransferCommandBuffer() const {
+			return m_transferCommandBuffer;
 		}
 
-		const vk::raii::Semaphore& getCommandExecutionSignalSemaphore() const {
-			return m_commandExecutionSignalSemaphores[m_currentCommandBufferIndex];
+		const vk::raii::Semaphore& getGraphicsCommandExecutionCompletedSemaphore() const {
+			return m_graphicsCommandExecutionCompletedSemaphores[m_currentGraphicsCommandBufferIndex];
+		}
+
+		const vk::raii::Semaphore& getGraphicsCommandPresentCompletedSemaphore() const {
+			return m_graphicsCommandPresentCompletedSemaphores[m_currentGraphicsCommandBufferIndex];
 		}
 
 		const vma::Allocator& getAllocator() const { return m_allocator; }
@@ -109,11 +122,11 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 			return m_physicalDevice.getSurfaceCapabilitiesKHR(*m_surface).currentTransform;
 		}
 
-		void nextCommandBuffer() {
-			++m_currentCommandBufferIndex %= m_commandBuffers.size();
+		void nextGraphicsCommandBuffer() {
+			++m_currentGraphicsCommandBufferIndex %= m_graphicsCommandBuffers.size();
 		}
 
-		void recreateSemaphores();
+		void recreatePresentCompletedSemaphores();
 
 	private:
 		vk::raii::Instance createInstance(const std::string_view& appName);
@@ -139,9 +152,12 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 
 		vk::raii::Device createDevice() const;
 
-		vk::raii::CommandPool createCommandPool() const;
+		vk::raii::CommandPool createCommandPool(uint32_t queueFamilyIndex) const;
 
-		std::vector<vk::raii::CommandBuffer> allocateCommandBuffers(size_t count) const;
+		std::vector<vk::raii::CommandBuffer> allocateCommandBuffers(
+			vk::raii::CommandPool& commandPool,
+			size_t count
+		) const;
 
 		vk::raii::Fence createFence(bool preSignaled) const;
 

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsContext.hpp
@@ -26,11 +26,11 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		IContextTarget& m_target;
 
 		vk::raii::Context m_context;
-		vk::raii::Instance m_instance = nullptr;
+		vk::raii::Instance m_instance;
 #ifdef MIRACLE_CONFIG_DEBUG
-		vk::raii::DebugUtilsMessengerEXT m_debugMessenger = nullptr;
+		vk::raii::DebugUtilsMessengerEXT m_debugMessenger;
 #endif
-		vk::raii::SurfaceKHR m_surface = nullptr;
+		vk::raii::SurfaceKHR m_surface;
 		vk::raii::PhysicalDevice m_physicalDevice = nullptr;
 		DeviceInfo m_deviceInfo;
 		vk::raii::Device m_device = nullptr;
@@ -118,9 +118,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	private:
 		vk::raii::Instance createInstance(const std::string_view& appName);
 
-		void checkExtensionsAvailable(
-			const std::span<const char*>& extensionNames
-		) const;
+		void checkExtensionsAvailable(const std::span<const char*>& extensionNames) const;
 
 #ifdef MIRACLE_CONFIG_DEBUG
 		void checkValidationLayersAvailable() const;

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsPipeline.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/GraphicsPipeline.cpp
@@ -205,18 +205,18 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	}
 
 	void GraphicsPipeline::bind() {
-		m_context.getCommandBuffer().bindPipeline(vk::PipelineBindPoint::eGraphics, *m_pipeline);
+		m_context.getGraphicsCommandBuffer().bindPipeline(vk::PipelineBindPoint::eGraphics, *m_pipeline);
 	}
 
 	void GraphicsPipeline::pushConstants(const Application::PushConstants& constants) {
-		m_context.getCommandBuffer().pushConstants<Application::VertexStagePushConstants>(
+		m_context.getGraphicsCommandBuffer().pushConstants<Application::VertexStagePushConstants>(
 			*m_layout,
 			vk::ShaderStageFlagBits::eVertex,
 			0,
 			constants.vertexStageConstants
 		);
 
-		m_context.getCommandBuffer().pushConstants<Application::FragmentStagePushConstants>(
+		m_context.getGraphicsCommandBuffer().pushConstants<Application::FragmentStagePushConstants>(
 			*m_layout,
 			vk::ShaderStageFlagBits::eFragment,
 			static_cast<uint32_t>(offsetof(Application::PushConstants, fragmentStageConstants)),

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/IndexBuffer.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/IndexBuffer.cpp
@@ -78,6 +78,6 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	}
 
 	void IndexBuffer::bind() {
-		m_context.getCommandBuffer().bindIndexBuffer(m_buffer, 0, vk::IndexType::eUint32);
+		m_context.getGraphicsCommandBuffer().bindIndexBuffer(m_buffer, 0, vk::IndexType::eUint32);
 	}
 }

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/SurfaceExtent.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/SurfaceExtent.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
-#include <optional>
+#include <variant>
 
 #include "Vulkan.hpp"
 
 namespace Miracle::Infrastructure::Graphics::Vulkan {
-	struct SurfaceExtent {
-		std::optional<vk::Extent2D> extent = {};
+	struct SurfaceExtentBounds {
 		vk::Extent2D minExtent = {};
 		vk::Extent2D maxExtent = {};
+	};
+
+	struct SurfaceExtent {
+		std::variant<vk::Extent2D, SurfaceExtentBounds> extent = {};
 	};
 }

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.cpp
@@ -139,9 +139,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		auto& swapchainSupport = m_context.getDeviceInfo().extensionSupport.swapchainSupport.value();
 
 		if (useTripleBuffering) {
-			if (swapchainSupport.hasTripleBufferingSupport) {
-				return 3;
-			}
+			if (swapchainSupport.hasTripleBufferingSupport) return 3;
 
 			m_logger.warning("Triple buffering not supported. Falling back to double buffering");
 		}

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.cpp
@@ -137,7 +137,22 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 
 		m_imageIndex = getNextImageIndex();
 
-		m_logger.info("Vulkan swapchain re-created");
+		m_logger.info(
+			std::format(
+				"Vulkan swapchain re-created with {} images and {} present mode",
+				m_images.size(),
+				vk::to_string(m_presentMode)
+			)
+		);
+	}
+
+	void Swapchain::setVsync(bool useVsync) {
+		m_presentMode = selectPresentMode(useVsync);
+	}
+
+	void Swapchain::setTripleBuffering(bool useTripleBuffering) {
+		m_minimumImageCount = selectMinimumImageCount(useTripleBuffering);
+		m_presentMode = selectPresentMode(isUsingVsync());
 	}
 
 	uint32_t Swapchain::selectMinimumImageCount(bool useTripleBuffering) const {

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
@@ -43,6 +43,18 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 
 		virtual void recreate() override;
 
+		virtual bool isUsingVsync() const override {
+			return m_presentMode != vk::PresentModeKHR::eImmediate;
+		}
+
+		virtual void setVsync(bool useVsync) override;
+
+		virtual bool isUsingTripleBuffering() const override {
+			return m_minimumImageCount > 2;
+		}
+
+		virtual void setTripleBuffering(bool useTripleBuffering) override;
+
 		const vk::raii::RenderPass& getRenderPass() const { return m_renderPass; }
 
 	private:

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
@@ -14,11 +14,11 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		Application::ILogger& m_logger;
 		GraphicsContext& m_context;
 
-		uint32_t m_preferredImageCount;
+		uint32_t m_minimumImageCount;
 		const vk::SurfaceFormatKHR m_surfaceFormat;
 		vk::Extent2D m_imageExtent;
 		vk::PresentModeKHR m_presentMode;
-		vk::raii::SwapchainKHR m_swapchain = nullptr;
+		vk::raii::SwapchainKHR m_swapchain;
 		std::vector<std::pair<vk::Image, vk::raii::ImageView>> m_images;
 		vk::raii::RenderPass m_renderPass = nullptr;
 		std::vector<vk::raii::Framebuffer> m_frameBuffers;
@@ -46,7 +46,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		const vk::raii::RenderPass& getRenderPass() const { return m_renderPass; }
 
 	private:
-		uint32_t selectImageCount(bool useTripleBuffering) const;
+		uint32_t selectMinimumImageCount(bool useTripleBuffering) const;
 
 		vk::SurfaceFormatKHR selectSurfaceFormat() const;
 

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
@@ -48,7 +48,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	private:
 		uint32_t selectImageCount(bool useTripleBuffering) const;
 
-		vk::SurfaceFormatKHR selectSurfaceFormat(bool useSrgb) const;
+		vk::SurfaceFormatKHR selectSurfaceFormat() const;
 
 		vk::Extent2D selectExtent() const;
 

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/Swapchain.hpp
@@ -46,7 +46,7 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 		const vk::raii::RenderPass& getRenderPass() const { return m_renderPass; }
 
 	private:
-		uint32_t selectImageCount() const;
+		uint32_t selectImageCount(bool useTripleBuffering) const;
 
 		vk::SurfaceFormatKHR selectSurfaceFormat(bool useSrgb) const;
 

--- a/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/VertexBuffer.cpp
+++ b/Miracle/src/Miracle/Infrastructure/Graphics/Vulkan/VertexBuffer.cpp
@@ -78,6 +78,6 @@ namespace Miracle::Infrastructure::Graphics::Vulkan {
 	}
 
 	void VertexBuffer::bind() {
-		m_context.getCommandBuffer().bindVertexBuffers(0, m_buffer, {0});
+		m_context.getGraphicsCommandBuffer().bindVertexBuffers(0, m_buffer, {0});
 	}
 }

--- a/Miracle/src/Miracle/Infrastructure/View/Glfw/Window.cpp
+++ b/Miracle/src/Miracle/Infrastructure/View/Glfw/Window.cpp
@@ -127,7 +127,7 @@ namespace Miracle::Infrastructure::View::Glfw {
 	vk::raii::SurfaceKHR Window::createVulkanSurface(
 		vk::raii::Instance& instance
 	) const {
-		VkSurfaceKHR surface = nullptr;
+		VkSurfaceKHR surface;
 		auto result = vk::Result(glfwCreateWindowSurface(*instance, m_window, nullptr, &surface));
 
 		if (result != vk::Result::eSuccess) {


### PR DESCRIPTION
Makes the following changes to the rendering-related code of Miracle:
- Improved macOS support in context creation
- Some code cleanup here and there
- Adds Vsync setting for swapchain
- Adds Triple buffering setting for swapchain
- Swapchain uses sRGB color format
- ColorRgb can translate sRGB color to linear color space
- Adds dedicated transfer queue if available

Other changes:
- Updates license

Closes #46